### PR TITLE
Fix crash of receiver thread due to calling async update from non-async context

### DIFF
--- a/custom_components/hass_onkyo_ng/__init__.py
+++ b/custom_components/hass_onkyo_ng/__init__.py
@@ -109,7 +109,7 @@ class OnkyoDataUpdateCoordinator(DataUpdateCoordinator):
         super().__init__(hass, _LOGGER, name=DOMAIN, update_interval=update_interval)
         self.onkyo_receiver.update()
 
-    def receive_data(self, data):
+    async def receive_data(self, data):
         _LOGGER.debug(f"Data: {data}")
         self.async_set_updated_data(data)
 


### PR DESCRIPTION
I'm still testing this - but I hope it fixes a bug where the thread crashes every few days