### PR TITLE
Compatibility for receivers without NRI command

### DIFF
--- a/custom_components/hass_onkyo_ng/__init__.py
+++ b/custom_components/hass_onkyo_ng/__init__.py
@@ -39,21 +39,28 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
         await onkyo_receiver.load_data()
 
-        retries = 3
-        receiver_info = None
-        while receiver_info is None and retries > 0:
-            retries -= 1
-            try:
-                receiver_info = onkyo_receiver.receiver_info
-            except Exception as error:
-                _LOGGER.error("Error getting receiver information", error)
-                raise error
+        receiver_info = await onkyo_receiver.get_receiver_info()
+        basic_receiver_info = await onkyo_receiver.get_basic_receiver_info()
+        udp_receiver_info =  await onkyo_receiver.get_udp_receiver_info()
+
+        if not receiver_info:
+            _LOGGER.error("Error getting receiver information")
+        if not basic_receiver_info:
+            _LOGGER.error("Error getting basic receiver information")
+        if not udp_receiver_info:
+            _LOGGER.error("Error getting basic receiver information via UDP")
 
         _LOGGER.info(receiver_info)
-        name = receiver_info.model
-        serial = receiver_info.serial
-        productid = receiver_info.productid
-        macaddress = receiver_info.macaddress
+        _LOGGER.info(basic_receiver_info)
+        _LOGGER.info(udp_receiver_info)
+        if (not receiver_info) or (not udp_receiver_info and not basic_receiver_info):
+            _LOGGER.error("Could not retrieve enough receiver information")
+            return False
+
+        name = receiver_info.model if receiver_info else udp_receiver_info['model_name']
+        serial = receiver_info.serial if receiver_info else udp_receiver_info['identifier']
+        productid = receiver_info.productid if receiver_info else "N/A"
+        macaddress = receiver_info.macaddress if receiver_info else udp_receiver_info['identifier']
         _LOGGER.debug("Found %s (Serial: %s) (Product ID: %s) (Mac Address: %s)", name, serial, productid, macaddress)
     except (ConnectionError) as error:
         _LOGGER.error("Cannot load data with error: %s", error)

--- a/custom_components/hass_onkyo_ng/config_flow.py
+++ b/custom_components/hass_onkyo_ng/config_flow.py
@@ -69,6 +69,24 @@ class OnkyoReceiverConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
         return schema
 
+    async def async_confirm_receiver(self, host: str) -> (str, str):
+        _LOGGER.info("Connecting to receiver: {}", host)
+        onkyo_receiver = OnkyoReceiver(host, hass=None)
+        try:
+            info = await onkyo_receiver.get_receiver_info()
+            if info:
+                _LOGGER.debug("Retrieved receiver information")
+                return info.macaddress, info.model
+
+            udp_info = await onkyo_receiver.get_udp_receiver_info()
+            if udp_info:
+                _LOGGER.debug("Found receiver basic information")
+                return udp_info['identifier'], udp_info['model_name']
+
+            raise UnsupportedModel()
+        finally:
+            onkyo_receiver.disconnect()
+
     async def async_step_user(self, user_input: dict[str, Any] = None) -> FlowResult:
         """Handle initial step of user config flow."""
 
@@ -84,28 +102,11 @@ class OnkyoReceiverConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     raise InvalidHost()
 
                 # now let's try and see if we can connect to a receiver
-                onkyo_receiver = OnkyoReceiver(host, hass=None)
-                try:
-                    info = onkyo_receiver.receiver_info
-                    if info:
-                        _LOGGER.debug("Found host: %s", host)
-                    else:
-                        _LOGGER.debug("Host not found: %s", host)
-                        raise ConnectionError()
+                unique_id, model_name = await self.async_confirm_receiver(host)
 
-                    # use the MAC as unique id
-                    unique_id = info.macaddress
-                    model_name = info.model
-
-                    # check if we got something
-                    if not unique_id:
-                        raise UnsupportedModel()
-
-                    # set the unique id for the entry, abort if it already exists
-                    await self.async_set_unique_id(unique_id)
-                    self._abort_if_unique_id_configured()
-                finally:
-                    onkyo_receiver.disconnect()
+                # set the unique id for the entry, abort if it already exists
+                await self.async_set_unique_id(unique_id)
+                self._abort_if_unique_id_configured()
 
                 # compile a name from model and serial
                 return self.async_create_entry(
@@ -146,27 +147,11 @@ class OnkyoReceiverConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # if the hostname already exists, we can stop
         self._async_abort_entries_match({CONF_HOST: self.host})
 
-        # now let's try and see if we can connect to a receiver
-        _LOGGER.info("Onkyo connect to {}", self.host)
-        onkyo_receiver = OnkyoReceiver(self.host, hass=None)
         try:
-            _LOGGER.info("CONNECTED")
-            onkyo_receiver.command_sync('main.power=query')
-            onkyo_receiver.command_sync('dock.receiver-information=query')
-            info = onkyo_receiver.receiver_info
-            if info:
-                _LOGGER.debug("Found host: %s", self.host)
-            else:
-                _LOGGER.debug("Host not found: %s", self.host)
-                raise ConnectionError()
-
-            # use the MAC as unique id
-            unique_id = info.macaddress
-            model_name = info.model
-
-            # check if we got something
-            if not unique_id:
-                return self.async_abort(reason="unsupported_model")
+            # now let's try and see if we can connect to a receiver
+            _LOGGER.info("Onkyo connect to {}", self.host)
+            # now let's try and see if we can connect to a receiver
+            unique_id, model_name = await self.async_confirm_receiver(self.host)
 
             # set the unique id for the entry, abort if it already exists
             await self.async_set_unique_id(unique_id)
@@ -186,8 +171,6 @@ class OnkyoReceiverConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return await self.async_step_zeroconf_confirm()
         except:
             return self.async_abort(reason="Exception during zeroconf flow")
-        finally:
-            onkyo_receiver.disconnect()
 
     async def async_step_zeroconf_confirm(
         self, user_input: dict[str, Any] = None

--- a/custom_components/hass_onkyo_ng/onkyo.py
+++ b/custom_components/hass_onkyo_ng/onkyo.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 from collections import defaultdict
 from eiscp.core import Receiver, command_to_iscp, iscp_to_command
-from eiscp.commands import COMMAND_MAPPINGS
+from eiscp.commands import COMMANDS, COMMAND_MAPPINGS
 from .const import *
 from .util import dict_merge
 from homeassistant.core import HomeAssistant
@@ -31,12 +31,12 @@ class OnkyoReceiver:
 
     class ReceiverSource:
         def __init__(self):
-            self.id: str | None = None
+            self.id: int | None = None
             self.name: str | None = None
             self.zones: List[OnkyoReceiver.ReceiverZone] = []
 
         def __str__(self):
-            return f"ReceiverSource(id: {self.id}, name: {self.name})"
+            return f"ReceiverSource(id: {self.id:02x}, name: {self.name})"
 
 
     class ReceiverInfo:
@@ -86,6 +86,40 @@ class OnkyoReceiver:
                             zone_map[zone_id].sources.append(receiver_source)
                     self.sources.append(receiver_source)
 
+    class ReceiverBasicInfo:
+        def __init__(self):
+            self.deviceid: str | None = None
+            self.zones: List[OnkyoReceiver.ReceiverZone] = []
+            self.sources: List[OnkyoReceiver.ReceiverSource] = []
+
+        def parse_xml(self, receiver_information_xml: str):
+            data = ET.fromstring(receiver_information_xml)
+            self.deviceid = data.find('deviceid').text
+            source_selector_cmd = {'main': 'SLI', 'zone2': 'SLZ', 'zone3': 'SL3', 'zone4': 'SL4'}
+            source_mapping = {}
+            for zone in data.find('zonelist').findall('zone'):
+                receiver_zone = OnkyoReceiver.ReceiverZone()
+                receiver_zone.id = int(zone.attrib['id'], 16)
+                receiver_zone.name = "main" if receiver_zone.id == 1 else "zone" + str(receiver_zone.id)
+                self.zones.append(receiver_zone)
+
+                # For now, provide a list of all zones available in the commands
+                source_command_args = COMMANDS[receiver_zone.name][source_selector_cmd[receiver_zone.name]]['values']
+                for source_id in source_command_args:
+                    if source_id not in ('UP', 'DOWN', 'QSTN'):
+                        name = source_command_args[source_id]['name']
+                        if not isinstance(name, str):
+                            name = "/".join(name)
+                        name = name.upper()
+                        if not source_id in source_mapping:
+                            receiver_source = OnkyoReceiver.ReceiverSource()
+                            receiver_source.id = int(source_id, 16)
+                            receiver_source.name = name
+                            source_mapping[source_id] = receiver_source
+                        receiver_source = source_mapping[source_id]
+                        receiver_source.zones.append(receiver_zone)
+                        receiver_zone.sources.append(receiver_source)
+
     def __init__(
         self,
         host: str,
@@ -97,17 +131,18 @@ class OnkyoReceiver:
         self._host = host
         self._receiver = Receiver(host)
         self._receiver.on_message = lambda msg: self._on_message_async(msg)
-        self._reverse_sound_mode_mapping = {}
-        self._receiver_info = None
+        self._sound_modes = {}
+        self._retrieved_receiver_info: bool = False
+        self._receiver_info: OnkyoReceiver.ReceiverInfo | None = None
+        self._receiver_basic_info: OnkyoReceiver.ReceiverBasicInfo | None = None
+        self._receiver_udp_info = None
         self._max_volume = max_volume
         self._receiver_max_volume = receiver_max_volume
         self._hdmi_out_supported = True
         self._audio_info_supported = True
         self._video_info_supported = True
         self.listeners = []
-        self._sync_pending: threading.Event = None
-        self._sync_command_prefix: str = None
-        self._sync_result = None
+        self._sync_commands = defaultdict(OnkyoReceiver.SyncCommand)
         self._hass = hass
         if hass:
             self._storage = Store[dict[str, Any]](hass, 1, f'onkyo_{host}')
@@ -115,8 +150,6 @@ class OnkyoReceiver:
             self._storage = None
 
         self.data = {
-            ATTR_SOURCES: [],
-            ATTR_SOUND_MODES: [],
             ATTR_PRESET: None,
             ATTR_HDMI_OUT: None,
             ATTR_RECEIVER_INFORMATION: {},
@@ -131,30 +164,57 @@ class OnkyoReceiver:
                 ATTR_VOLUME: None,
                 ATTR_SOURCE: None,
                 ATTR_SOUND_MODE: None,
+                ATTR_SOUND_MODES: [],
             }
 
-    @property
-    def receiver_info(self) -> OnkyoReceiver.ReceiverInfo:
-        if not self._receiver_info:
-            self.command_sync('dock.receiver-information=query')
+    async def get_all_receiver_info(self) -> None:
+        if not self._retrieved_receiver_info:
+            self._retrieved_receiver_info = True
+            # TODO: Retry only the failed ones
+            retries = 3
+            while retries > 0:
+                tasks = []
+                tasks.append(asyncio.create_task(self.command_async('dock.receiver-information=query')))
+                tasks.append(asyncio.create_task(self.raw_async('MDIQSTN')))
+                tasks.append(asyncio.create_task(self.command_udp_info()))
+                done, pending = await asyncio.wait(tasks, timeout=2)
+                for coroutine in pending:
+                    _LOGGER.error("Timeout waiting for receiver information")
+                    coroutine.cancel()
+                if len(pending) == 0:
+                    break
+                retries -= 1
+
+    async def get_receiver_info(self) -> OnkyoReceiver.ReceiverInfo:
+        await self.get_all_receiver_info()
         return self._receiver_info
 
-    @property
-    def zones(self) -> List[OnkyoReceiver.ReceiverZone]:
-        return self.receiver_info.zones
+    async def get_basic_receiver_info(self) -> OnkyoReceiver.ReceiverBasicInfo:
+        await self.get_all_receiver_info()
+        return self._receiver_basic_info
 
-    @property
-    def sources(self) -> List[OnkyoReceiver.ReceiverSource]:
-        return self.receiver_info.sources
+    async def get_udp_receiver_info(self):
+        await self.get_all_receiver_info()
+        return self._receiver_udp_info
+
+    async def get_zones(self) -> List[OnkyoReceiver.ReceiverZone]:
+        await self.get_all_receiver_info()
+        return self._receiver_info.zones if self._receiver_info else self._receiver_basic_info.zones
+
+    async def sources(self) -> List[OnkyoReceiver.ReceiverSource]:
+        await self.get_all_receiver_info()
+        return self._receiver_info.sources if self._receiver_info else self._receiver_basic_info.sources
 
     async def load_data(self):
         if self._storage:
             data = await self._storage.async_load()
             _LOGGER.info(f"Loaded data {data}")
             if data:
-                main_zone = data.get('zone_main', {})
-                self._reverse_sound_mode_mapping = main_zone.get('reverse_sound_mode_mapping', {})
-                self.data[ATTR_SOUND_MODES] = list(self._reverse_sound_mode_mapping.keys())
+                self._sound_modes = data.get('sound_modes', {})
+                for zone in _ZONE_NAMES:
+                    zone_key = f"{ATTR_ZONE}_{zone}"
+                    self.data[zone_key][ATTR_SOUND_MODES] = self._sound_modes.get(zone_key, [])
+
                 for listener in self.listeners:
                     listener(self.data)
 
@@ -164,9 +224,7 @@ class OnkyoReceiver:
 
     def _data_to_save(self):
         data = {
-            'zone_main': {
-                'reverse_sound_mode_mapping': self._reverse_sound_mode_mapping,
-            },
+            'sound_modes': self._sound_modes
         }
         return data
 
@@ -210,9 +268,11 @@ class OnkyoReceiver:
                 elif command == "listening-mode":
                     sound_modes = self._parse_onkyo_payload((command, attrib))
                     sound_mode = "_".join(sound_modes)
-                    if not sound_mode in self._reverse_sound_mode_mapping:
-                        self._reverse_sound_mode_mapping[sound_mode] = sound_modes[0]
-                        updates[ATTR_SOUND_MODES] = list(self._reverse_sound_mode_mapping.keys())
+                    if not zone_key in self._sound_modes:
+                        self._sound_modes[zone_key] = []
+                    if not sound_mode in self._sound_modes[zone_key]:
+                        self._sound_modes[zone_key].append(sound_mode)
+                        updates[zone_key][ATTR_SOUND_MODES] = self._sound_modes[zone_key]
                         self.store_data()
                     updates[zone_key][ATTR_SOUND_MODE] = sound_mode
             elif zone == 'dock':
@@ -229,6 +289,13 @@ class OnkyoReceiver:
                 _LOGGER.warning(f"Ignoring zone {zone}")
         except ValueError:
             _LOGGER.debug(f"Cannot decode raw message: {message}")
+            if message[:3] == "MDI":
+                _LOGGER.debug("Got receiver basic info. Parsing")
+                info = OnkyoReceiver.ReceiverBasicInfo()
+                info.parse_xml(message[3:])
+                self._receiver_basic_info = info
+                updates[ATTR_IDENTIFIER] = info.deviceid
+                self.store_data()
 
         if updates:
             dict_merge(self.data, updates)
@@ -239,13 +306,11 @@ class OnkyoReceiver:
             else:
                 _LOGGER.warning("Update lost (no event loop)")
 
-        if self._sync_pending:
-            _LOGGER.debug(f"Received {message} whilst waiting for sync response {self._sync_command_prefix}")
-            if self._sync_command_prefix == message[:3]:
-                _LOGGER.debug("Handled sync response")
-                self._sync_result = message
-                self._sync_pending.set()
-                return
+        message_prefix = message[:3]
+        if message_prefix in self._sync_commands:
+            _LOGGER.debug(f"Received {message} whilst waiting for sync response")
+            sync_command = self._sync_commands.pop(message_prefix)
+            sync_command._set_result(message)
 
     def _parse_onkyo_payload(self, payload):
         """Parse a payload returned from the eiscp library."""
@@ -311,36 +376,44 @@ class OnkyoReceiver:
         self._receiver._ensure_socket_connected()
         self._receiver.send(command_to_iscp(command))
 
-    def raw_sync(self, raw_command: str):
+    async def raw_async(self, raw_command: str):
         """Run a raw eiscp command synchronously."""
         _LOGGER.debug(f"Sending sync command {raw_command}")
-        self._sync_command_prefix = raw_command[:3]
-        self._sync_pending = threading.Event()
+        sync_command_prefix = raw_command[:3]
+        sync_command = self._sync_commands[sync_command_prefix]
+        event = Event_ts()
+        sync_command.add_event(event)
         self._receiver.send(raw_command)
-        try:
-            if not self._sync_pending.wait(10):
-                raise ValueError("Timeout waiting for response")
-            result_raw = self._sync_result
-            _LOGGER.debug(f"Result: {result_raw}")
-            return result_raw
-        finally:
-            self._sync_pending = None
-            self._sync_command_prefix = None
-            self._sync_result = None
+        await event.wait()
+        result_raw = sync_command.result
+        _LOGGER.debug(f"Result: {result_raw}")
+        return result_raw
 
-    def command_sync(self, command: str):
-        """Run an eiscp command synchronously."""
+    async def command_async(self, command: str, timeout=None):
+        """Run command and wait for response"""
         _LOGGER.debug(f"Sending sync command {command}")
         raw_command = command_to_iscp(command)
-        result_raw = self.raw_sync(raw_command)
+        result_raw = await asyncio.wait_for(self.raw_async(raw_command), timeout)
         result = iscp_to_command(result_raw)
         _LOGGER.debug(f"Result: {result}")
-        return result
+
+    async def command_udp_info(self):
+        retries = 5
+        while not self._receiver_udp_info and retries > 0:
+            retries -= 1
+            # This only waits 0.1 seconds and may miss the response, so retry a few times
+            self._receiver_udp_info = self._receiver.info
+            self.data[ATTR_NAME] = self._receiver_udp_info['model_name']
+        return self._receiver_udp_info
 
     def select_source(self, zone: ReceiverZone, source_id: int):
         cmd = "input-selector" if zone.name == "main" else "selector"
         raw_cmd = COMMAND_MAPPINGS[zone.name][cmd] + f"{source_id:02x}"
         self.raw(raw_cmd)
+
+    def select_sound_mode(self, zone: ReceiverZone, sound_mode: str):
+        sound_mode_selection = sound_mode.split("_")[0]
+        self.command(f"{zone.name}.listening-mode={sound_mode_selection}")
 
     def update(self):
         """Get the latest state from the device."""
@@ -378,3 +451,24 @@ class OnkyoReceiver:
                 self.command(f"{zone}.muting=query")
                 # retrieve source information
                 self.command(f"{zone}.selector=query")
+
+    class SyncCommand:
+        def __init__(self):
+            self._event_list: List[threading.Event | Event_ts] = []
+            self._result: str | None = None
+
+        def add_event(self, event: threading.Event | Event_ts) -> None:
+            self._event_list.append(event)
+
+        def _set_result(self, result: str) -> None:
+            self._result = result
+            for event in self._event_list:
+                event.set()
+
+        @property
+        def result(self) -> str:
+            return self._result
+
+class Event_ts(asyncio.Event):
+    def set(self):
+        self._loop.call_soon_threadsafe(super().set)


### PR DESCRIPTION
I have attempted to fix the integration for receivers without the NRI command.
This is by falling back to the previous UDP method to retrieve the serial/mac/model, and for the sources, providing all the ones available in the command mapping. Its not ideal, but should make it usable.

I also reworked waiting for synchronous commands to use asyncio, and cleaned up the sound mode handling