### PR TITLE
Default config if receiver info not available

### DIFF
--- a/custom_components/hass_onkyo_ng/__init__.py
+++ b/custom_components/hass_onkyo_ng/__init__.py
@@ -40,27 +40,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await onkyo_receiver.load_data()
 
         receiver_info = await onkyo_receiver.get_receiver_info()
-        basic_receiver_info = await onkyo_receiver.get_basic_receiver_info()
-        udp_receiver_info =  await onkyo_receiver.get_udp_receiver_info()
 
         if not receiver_info:
             _LOGGER.error("Error getting receiver information")
-        if not basic_receiver_info:
-            _LOGGER.error("Error getting basic receiver information")
-        if not udp_receiver_info:
-            _LOGGER.error("Error getting basic receiver information via UDP")
-
-        _LOGGER.info(receiver_info)
-        _LOGGER.info(basic_receiver_info)
-        _LOGGER.info(udp_receiver_info)
-        if (not receiver_info) or (not udp_receiver_info and not basic_receiver_info):
-            _LOGGER.error("Could not retrieve enough receiver information")
             return False
 
-        name = receiver_info.model if receiver_info else udp_receiver_info['model_name']
-        serial = receiver_info.serial if receiver_info else udp_receiver_info['identifier']
-        productid = receiver_info.productid if receiver_info else "N/A"
-        macaddress = receiver_info.macaddress if receiver_info else udp_receiver_info['identifier']
+        _LOGGER.info(receiver_info)
+
+        name = receiver_info.model
+        serial = receiver_info.serial
+        productid = receiver_info.productid
+        macaddress = receiver_info.macaddress
         _LOGGER.debug("Found %s (Serial: %s) (Product ID: %s) (Mac Address: %s)", name, serial, productid, macaddress)
     except (ConnectionError) as error:
         _LOGGER.error("Cannot load data with error: %s", error)

--- a/custom_components/hass_onkyo_ng/config_flow.py
+++ b/custom_components/hass_onkyo_ng/config_flow.py
@@ -78,11 +78,6 @@ class OnkyoReceiverConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 _LOGGER.debug("Retrieved receiver information")
                 return info.macaddress, info.model
 
-            udp_info = await onkyo_receiver.get_udp_receiver_info()
-            if udp_info:
-                _LOGGER.debug("Found receiver basic information")
-                return udp_info['identifier'], udp_info['model_name']
-
             raise UnsupportedModel()
         finally:
             onkyo_receiver.disconnect()

--- a/custom_components/hass_onkyo_ng/media_player.py
+++ b/custom_components/hass_onkyo_ng/media_player.py
@@ -56,13 +56,14 @@ async def async_setup_entry(
     receiver: OnkyoReceiver = coordinator.onkyo_receiver
 
     receiver_info = await receiver.get_receiver_info()
-    receiver_basic_info = await receiver.get_basic_receiver_info()
+    if not receiver_info:
+        _LOGGER.error("Could not retrieve receiver info")
+        return False
 
-    zones = receiver_info.zones if receiver_info else receiver_basic_info.zones
-    _LOGGER.info(f"Creating mediaplayer entities for zones: {zones}")
+    _LOGGER.info(f"Creating mediaplayer entities for zones: {receiver_info.zones}")
 
     # Create a media player entity for each supported zone
-    for zone in zones:
+    for zone in receiver_info.zones:
         _LOGGER.info(f"Set up Onkyo zone: {zone.name}")
         entities.append(OnkyoMediaPlayer(coordinator, zone))
 


### PR DESCRIPTION
Abandon the MDI command which doesn't seem to give any useful information anyway.
Use a default config of all 4 zones and all sources for now, so that this should work for any Onkyo receiver in the short term.
The plan after that could be one of (or a combination of) these options I think:
- go back to scanning the sources at setup, though it may take a long time for all the zones
- embed mappings of receiver model to zones+sources in the integration (I prefer this approach)
- store the sources (and zones?) that have been seen dynamically, as is currently done with the sound modes. So the user would need to manually select the zone on the receiver, then it would show up in HA. (I like this as a backup if we don't have an explicit mapping for the model number)
- let the user select the zones they want to use in the config flow