### PR TITLE
fix crash whenever a zone returns a None for volume

### DIFF
--- a/custom_components/hass_onkyo_ng/onkyo.py
+++ b/custom_components/hass_onkyo_ng/onkyo.py
@@ -255,7 +255,10 @@ class OnkyoReceiver:
                 elif command in ["audio-muting", "muting"]:
                     updates[zone_key][ATTR_MUTE] = attrib == "on"
                 elif command in ("master-volume", "volume"):
-                    updates[zone_key][ATTR_VOLUME] = attrib / (self._receiver_max_volume * self._max_volume / 100)
+                    if attrib == 'N/A':
+                        updates[zone_key][ATTR_VOLUME] = 0.0
+                    else:
+                        updates[zone_key][ATTR_VOLUME] = attrib / (self._receiver_max_volume * self._max_volume / 100)
                 elif command in ["input-selector", "selector"]:
                     source_id = int(message[-2:], 16)
                     updates[zone_key][ATTR_SOURCE] = source_id


### PR DESCRIPTION
Fix a crash for my onkyo TX-NR676E receiver, which returns a volume : None for zone 2, causing the hass_onkyo_ng integration to crash for this receiver