### PR TITLE
Configurable receiver max volume

### DIFF
--- a/custom_components/hass_onkyo_ng/__init__.py
+++ b/custom_components/hass_onkyo_ng/__init__.py
@@ -29,12 +29,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # get the receiver
     update_interval = entry.data[CONF_SCAN_INTERVAL]
 
+    # Max volume setting
+    max_volume = entry.data.get(CONF_MAX_VOLUME, ONKYO_DEFAULT_RECEIVER_MAX_VOLUME)
+
     try:
         onkyo_receiver = OnkyoReceiver(
             host=host,
             hass=hass,
             max_volume=ONKYO_SUPPORTED_MAX_VOLUME,
-            receiver_max_volume=ONKYO_DEFAULT_RECEIVER_MAX_VOLUME,
+            receiver_max_volume=max_volume,
         )
         await onkyo_receiver.load_data()
 

--- a/custom_components/hass_onkyo_ng/config_flow.py
+++ b/custom_components/hass_onkyo_ng/config_flow.py
@@ -17,6 +17,8 @@ from .onkyo import OnkyoReceiver
 from .const import (
     DOMAIN,
     POLLING_INTERVAL,
+    CONF_MAX_VOLUME,
+    ONKYO_DEFAULT_RECEIVER_MAX_VOLUME,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -65,6 +67,11 @@ class OnkyoReceiverConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     CONF_SCAN_INTERVAL,
                     default=user_input.get(CONF_SCAN_INTERVAL, POLLING_INTERVAL),
                 ): vol.All(cv.positive_int, vol.Range(min=10, max=600)),
+                # Some receivers use 0-80, some 0-100, and some 0-200 (0-100 but in 0.5 increments)
+                vol.Required(
+                    CONF_MAX_VOLUME,
+                    default=user_input.get(CONF_MAX_VOLUME, ONKYO_DEFAULT_RECEIVER_MAX_VOLUME),
+                ): vol.All(cv.positive_int, vol.Range(min=10, max=200)),
             }
         )
         return schema

--- a/custom_components/hass_onkyo_ng/const.py
+++ b/custom_components/hass_onkyo_ng/const.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 DOMAIN = "hass_onkyo_ng"
 PLATFORMS = ["media_player"]
 
+CONF_MAX_VOLUME = "max_volume"
+
 POLLING_INTERVAL = 30
 
 ATTR_ZONE = "zone"


### PR DESCRIPTION
For the volume range, some receivers use 0-80, some 0-100, and some 0-200 (displayed as 0-100 in 0.5 increments).
Allow the user to select this at config time, in the absence of some mapping by receiver model.